### PR TITLE
 - add close option so the program may gracefully exit

### DIFF
--- a/lib/statsd.js
+++ b/lib/statsd.js
@@ -184,4 +184,8 @@ Client.prototype.send = function (stat, value, type, sampleRate, tags, callback)
   }
 };
 
+Client.prototype.close = function(){
+    this.socket.close();
+}
+
 exports.StatsD = Client;


### PR DESCRIPTION
Just export the close function from the base fork to this one.
Closing the socket is necessary for the app to gracefully exit.